### PR TITLE
Remove itv.ard - prevents streaming from ARD

### DIFF
--- a/smart-tv
+++ b/smart-tv
@@ -216,7 +216,6 @@ scribe.logs.roku.com
 # Other
 get.geo.opera.com
 xml.opera.com
-itv.ard.de
 cert-test.sandbox.google.com
 googleads.g.doubleclick.net
 hbbtv.redbutton.de


### PR DESCRIPTION
Dieser Eintrag verhindert streaming von der ARD Mediathek