### PR TITLE
Add cedock.com to the blacklist

### DIFF
--- a/smart-tv.txt
+++ b/smart-tv.txt
@@ -1,5 +1,5 @@
 # Smart TV Blocklist
-# Last updated: March 11, 2025
+# Last updated: September 15, 2025
 
 # This is a blocklist to block Smart TVs sending data home.
 # Please contribute domains, either by issues or PRs.

--- a/smart-tv.txt
+++ b/smart-tv.txt
@@ -325,6 +325,7 @@ leiniao.com
 tcllauncher.com
 my7v.com
 huan.tv
+cedock.com
 # Consider if you are using Baidu services or not to blacklist it here.
 # www.baidu.com
 


### PR DESCRIPTION
I have seen specifically `na-newuser-tcl.cedock.com` come through a bunch and haven't had issues blocking it, but I blocked the root, and haven't had a problem yet, but also haven't seen requests to any other subdomain.